### PR TITLE
Issue_5 Add support for r10k Puppetfile's opts

### DIFF
--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -14,7 +14,7 @@ module Librarian
       include Local
 
       lock_name 'GIT'
-      spec_options [:ref, :path]
+      spec_options [:ref, :branch, :tag, :commit, :path]
 
       DEFAULTS = {
         :ref => 'master'
@@ -23,13 +23,17 @@ module Librarian
       attr_accessor :environment
       private :environment=
 
-      attr_accessor :uri, :ref, :sha, :path
-      private :uri=, :ref=, :sha=, :path=
+      attr_accessor :uri, :ref, :branch, :tag, :commit, :sha, :path
+      private :uri=, :ref=, :branch=, :tag=, :commit=, :sha=, :path=
 
       def initialize(environment, uri, options)
+        validate_options(uri, options)
+
         self.environment = environment
         self.uri = uri
-        self.ref = options[:ref] || DEFAULTS[:ref]
+        self.ref = options[:ref] || options[:branch] ||
+                   options[:tag] || options[:commit] ||
+                   DEFAULTS[:ref]
         self.sha = options[:sha]
         self.path = options[:path]
 
@@ -173,6 +177,13 @@ module Librarian
         @runtime_cache ||= environment.runtime_cache.keyspace(self.class.name)
       end
 
+      def validate_options(uri, options)
+        found = 0; [:ref, :branch, :tag, :commit].each do |opt|
+          found += 1 if options.has_key?(opt)
+          found > 1 and raise Error,
+            "at #{uri}, use only one of ref, branch, tag, or commit"
+        end
+      end
     end
   end
 end

--- a/spec/unit/source/git_spec.rb
+++ b/spec/unit/source/git_spec.rb
@@ -17,11 +17,17 @@ module Librarian
 
         context "with an unknown option" do
           it "should raise" do
-            expect { described_class.from_spec_args(env, "some://git/repo.git", :branch => "megapatches") }.
-              to raise_error Error, "unrecognized options: branch"
+            expect { described_class.from_spec_args(env, "some://git/repo.git", :I_am_unknown => "megapatches") }.
+              to raise_error Error, "unrecognized options: I_am_unknown"
           end
         end
 
+        context "with invalid options" do
+          it "should raise" do
+            expect { described_class.from_spec_args(env, "some://git/repo.git", {:ref => "megapatches", :branch => "megapatches"}) }.
+              to raise_error Error, "at some://git/repo.git, use only one of ref, branch, tag, or commit"
+          end
+        end
       end
 
     end


### PR DESCRIPTION
Add feature for Librarian to recognise r10k's :commit, :tag, and :branch
as accepted aliases for Librarian's :ref. Librarian will fail if more
than one of these options are specified.

A known issue with this implementation is that, internally, all of these
options are still treated as git refs. In other words, Librarian will
not notice if the user calls what is really a tag a commit and so on.
