### PR TITLE
Be specific about exposing git environment variables

### DIFF
--- a/lib/librarian/cli.rb
+++ b/lib/librarian/cli.rb
@@ -192,7 +192,7 @@ module Librarian
       debug { "Git: #{Source::Git::Repository.bin}" }
       debug { "Git Version: #{Source::Git::Repository.git_version}" }
       debug { "Git Environment Variables:" }
-      git_env = ENV.to_a.select{|(k, v)| k =~ /\AGIT/}.sort_by{|(k, v)| k}
+      git_env = ENV.to_a.select{|(k, v)| k =~ /\AGIT_/}.sort_by{|(k, v)| k}
       if git_env.empty?
         debug { "  (empty)" }
       else


### PR DESCRIPTION
The regex used to output the git environment variables only checks the
the start of the variable begins with `GIT`. In most circumstances, this
would be fine. However, if you have environment variables for `GITHUB`
(say access tokens) these are also exposed and this becomes a potential
security risk.

To remedy this, I've just updated the regex to check the environment
variable name begins with `GIT_` which based on my research _should_
cover all the core variables that can be expected here.