### PR TITLE
do not fail on tag shift

### DIFF
--- a/lib/librarian/source/git/repository.rb
+++ b/lib/librarian/source/git/repository.rb
@@ -57,6 +57,7 @@ module Librarian
         def fetch!(remote, options = { })
           command = %W(fetch #{remote} --quiet)
           command << "--tags" if options[:tags]
+          command << "--force" if options[:tags]
           run!(command, :chdir => true)
         end
 


### PR DESCRIPTION
`librarian-puppet update` fails with a generic error ("Could not checkout https://path-to-git.git:") if a tag was used and shifted to a different commit.

The error originates from librarianp failing on existing tags. Behaviour in original git for clarification:

```
git fetch --tags
From https://path-to-git.git:
 ! [rejected]        latest_tag -> latest_tag  (would clobber existing tag)
```

Solution: Add `--force` param to `git fetch --tags` so it replaces the old tag.