### PR TITLE
search for the Rakefile relatively to pwd

### DIFF
--- a/lib/librarian/rspec/support/cli_macro.rb
+++ b/lib/librarian/rspec/support/cli_macro.rb
@@ -51,7 +51,7 @@ module Librarian
         def self.included(base)
           base.instance_exec do
             let(:project_path) do
-              project_path = Pathname.new(__FILE__).expand_path
+              project_path = Pathname.pwd.expand_path
               project_path = project_path.dirname until project_path.join("Rakefile").exist?
               project_path
             end


### PR DESCRIPTION
This is a fix (workaround?) for https://bugs.debian.org/987113

In most cases, we run the spec tests from a full source checkout,
testing the current state in the VCS.

However, in Debian, we also want to test that the built package is
actually working fine. To do so, we install the package and then re-use
the spec tests from the source, but now running against the *installed*
version of the code.

Obviously, we don't install the Rakefile, as it contains nothing of use
for the end-users of the package.

But now, if we'd run the tests, they will try to find the Rakefile by
looking at the path of cli_macro.rb (in /usr/share/rubygems-integration)
and call .dirname on it, until path.join("Rakefile") exists, which will
never be true (it will traverse until / and loop there).

Instead, we can try to start from the place where we call the tests from
(pwd) and should get a path where it can find the Rakefile and be happy.

Now, after explaining all this, the only question for me is: why does it
even look for a Rakefile? Because the source tree of librarian doesn't
look like a librarian project anyways?