### PR TITLE
Fix one more instance of block passing

### DIFF
--- a/lib/librarian/dsl/receiver.rb
+++ b/lib/librarian/dsl/receiver.rb
@@ -25,8 +25,8 @@ module Librarian
         end
       end
 
-      def run(specfile = nil)
-        specfile = Proc.new if block_given?
+      def run(specfile = nil, &block)
+        specfile = block if block
 
         case specfile
         when Pathname


### PR DESCRIPTION
76d38767670324a2347d8785ec48a6d5d5266ef6 missed this one and is needed on Ruby 3. Without this the librarian-puppet test suite can't pass.

Fixes: 76d38767670324a2347d8785ec48a6d5d5266ef6