### PR TITLE
Mitigation for the shifting/moving/mutable tags issue (#13)

### DIFF
--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -153,7 +153,9 @@ module Librarian
         remote = repository.default_remote
         runtime_cache.once ['repository-update', uri, remote, ref].to_s do
           repository.fetch! remote
-          repository.fetch! remote, :tags => true
+          repository.fetch! remote,
+                            :tags => true,
+                            :force => environment.config_db['allow-moving-tags']
         end
       end
 

--- a/lib/librarian/source/git/repository.rb
+++ b/lib/librarian/source/git/repository.rb
@@ -60,6 +60,7 @@ module Librarian
           command = %W(fetch #{remote})
           command << '--quiet' unless environment.ui.debug?
           command << "--tags" if options[:tags]
+          command << "--force" if options[:force]
           run!(command, :chdir => true)
         end
 


### PR DESCRIPTION
This workaround aims at addressing #13 in a backward-compatible manner:
* Add an optional 'force' switch to the fetch! method (off by default)
* Use the 'allow-moving-tags' config key to enable force-fetching tags (also off by default)

When using Librarian-puppet, the `LIBRARIAN_PUPPET_ALLOW_MOVING_TAGS` environment variable can be used to enable the behavior without modifying the existing local or global configurations.